### PR TITLE
Use bootLoggable instead of boot()

### DIFF
--- a/src/Traits/Loggable.php
+++ b/src/Traits/Loggable.php
@@ -26,10 +26,8 @@ trait Loggable
         ]);
     }
 
-    public static function boot()
+    public static function bootLoggable()
     {
-        parent::boot();
-
         if (config('user-activity.log_events.on_edit', false)) {
             self::updated(function ($model) {
                 self::logToDb($model, 'edit');


### PR DESCRIPTION
It's better to use bootTrait instead of overriding the base boot method to keep the possibility to override it in model
I suggest you read this [https://laravel-news.com/booting-eloquent-model-traits](https://laravel-news.com/booting-eloquent-model-traits)