### PR TITLE
Add possibilty to exclude model from logging in case model base parent

### DIFF
--- a/config/user-activity.php
+++ b/config/user-activity.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'activated' => true,
     'middleware'       => ['web', 'auth'],
     'route_path'       => 'admin/user-activity',
     'admin_panel_path' => 'admin/dashboard',

--- a/src/Listeners/LockoutListener.php
+++ b/src/Listeners/LockoutListener.php
@@ -22,7 +22,8 @@ class LockoutListener
 
     public function handle($event)
     {
-        if (!config('user-activity.log_events.on_lockout', false)) return;
+        if (!config('user-activity.log_events.on_lockout', false)
+            || !config('user-activity.activated', true)) return;
 
         if (!$event->request->has('email')) return;
         $user = $this->userInstance::where('email', $event->request->input('email'))->first();

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -15,7 +15,8 @@ class LoginListener
 
     public function handle(Login $event)
     {
-        if (!config('user-activity.log_events.on_login', false)) return;
+        if (!config('user-activity.log_events.on_login', false)
+            || !config('user-activity.activated', true)) return;
 
         $user = $event->user;
         $dateTime = date('Y-m-d H:i:s');

--- a/src/Traits/Loggable.php
+++ b/src/Traits/Loggable.php
@@ -10,7 +10,7 @@ trait Loggable
 
     static function logToDb($model, $logType)
     {
-        if (!auth()->check() || $model->excludeLogging || !config('user-activity.activated')) return;
+        if (!auth()->check() || $model->excludeLogging || !config('user-activity.activated', true)) return;
         if ($logType == 'create') $originalData = json_encode($model);
         else $originalData = json_encode($model->getOriginal());
 

--- a/src/Traits/Loggable.php
+++ b/src/Traits/Loggable.php
@@ -10,7 +10,7 @@ trait Loggable
 
     static function logToDb($model, $logType)
     {
-        if (!auth()->check() || $model->excludedModelLogging) return;
+        if (!auth()->check() || $model->excludedModelLogging || !config('user-activity.activated')) return;
         if ($logType == 'create') $originalData = json_encode($model);
         else $originalData = json_encode($model->getOriginal());
 

--- a/src/Traits/Loggable.php
+++ b/src/Traits/Loggable.php
@@ -10,7 +10,7 @@ trait Loggable
 
     static function logToDb($model, $logType)
     {
-        if (!auth()->check()) return;
+        if (!auth()->check() || $model->excludedModelLogging) return;
         if ($logType == 'create') $originalData = json_encode($model);
         else $originalData = json_encode($model->getOriginal());
 

--- a/src/Traits/Loggable.php
+++ b/src/Traits/Loggable.php
@@ -10,7 +10,7 @@ trait Loggable
 
     static function logToDb($model, $logType)
     {
-        if (!auth()->check() || $model->excludedModelLogging || !config('user-activity.activated')) return;
+        if (!auth()->check() || $model->excludeLogging || !config('user-activity.activated')) return;
         if ($logType == 'create') $originalData = json_encode($model);
         else $originalData = json_encode($model->getOriginal());
 


### PR DESCRIPTION
Hi, I am request this PR because I faced a possible scenario among a lot of developers.

A best practice that I know is to create a BaseClass that extends the Model class of Laravel, and then in all of the project's models instead of extends the Laravel Model Class, extend the BaseClass, because many times existing some configuration common between all of the models

In the case that a client wants to log the changes of all of models it will just necessary to use the Loggable Trait inside BaseClass

But if he needs to excluded just one or a few models, would have to import the trait in all models except the ones he wants to excluded from the logging

So I am put among the auth condition another condition to check if the property excludedModelLogging is true

By default in Laravel, in case the property does not exists it will return null

So if the user is not authenticated or the model has the excludedModelLogging property setted to true, will not be logged.



Additionally, I added the config option to activate or desactivate the logs inserts.



I hope this PR be approved because I am facing the exacly scenario I described.

Thanks for this great package, and I will contribute with it more.