### PR TITLE
Changes the original models' data to raw original

### DIFF
--- a/src/Traits/Loggable.php
+++ b/src/Traits/Loggable.php
@@ -12,7 +12,7 @@ trait Loggable
     {
         if (!auth()->check()) return;
         if ($logType == 'create') $originalData = json_encode($model);
-        else $originalData = json_encode($model->getOriginal());
+        else $originalData = json_encode($model->getRawOriginal());
 
         $tableName = $model->getTable();
         $dateTime = date('Y-m-d H:i:s');


### PR DESCRIPTION
Hi, the logToDb methods in Loggable trait is using the getOriginal() method from the Model

But in case the model have some mutator, it will be save as a modification even there was none

To fix this, I changed to instead call getOriginal() call getRawOriginal(), so even the model has mutators it wont be trigged.